### PR TITLE
Update GameStatusUpdate.cs

### DIFF
--- a/MonoBehaviours/GameStatusUpdate.cs
+++ b/MonoBehaviours/GameStatusUpdate.cs
@@ -33,7 +33,7 @@ namespace Infoholic.MonoBehaviours
         private Player getLocalPlayer()
         {
             Player player = null;
-            PlayerManager.instance.players.ForEach(p => { if (p.data.view.IsMine) player = p; });
+            PlayerManager.instance.players.ForEach(p => { if (p.data.view.IsMine && !p.GetComponent<PlayerAPI>().enabled) player = p; });
             return player;
         }
 


### PR DESCRIPTION
Added !p.GetComponent<PlayerAPI>().enabled in 
PlayerManager.instance.players.ForEach(p => { if (p.data.view.IsMine) player = p; });
so it will exclude the bot and not display the last bot info. display the player info instead.
this will add support for "RoundWithBots" mod.